### PR TITLE
Switch to invoking 'bash' instead of '/bin/bash'.

### DIFF
--- a/lib/vagrant-host-shell/provisioner.rb
+++ b/lib/vagrant-host-shell/provisioner.rb
@@ -2,7 +2,7 @@ module VagrantPlugins::HostShell
   class Provisioner < Vagrant.plugin('2', :provisioner)
     def provision
       result = Vagrant::Util::Subprocess.execute(
-        '/bin/bash',
+        'bash',
         '-c',
         config.inline,
         :notify => [:stdout, :stderr],


### PR DESCRIPTION
This fixes #3 and works on Mac and Windows.
