### PR TITLE
Start 0.0.5pre. Color output red and green like the shell provisioner.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ test/tmp
 test/version_tmp
 tmp
 .vagrant
+*.swo
+*.swp

--- a/lib/vagrant-host-shell/provisioner.rb
+++ b/lib/vagrant-host-shell/provisioner.rb
@@ -8,11 +8,19 @@ module VagrantPlugins::HostShell
         :notify => [:stdout, :stderr],
         :workdir => config.cwd
       ) do |io_name, data|
-        @machine.env.ui.info "[#{io_name}] #{data}"
+        options = {
+          new_line: false,
+          prefix: false,
+        }
+
+        color = io_name == :stdout ? :green : :red
+        options[:color] = color # if !config.keep_color
+
+        @machine.env.ui.info(data, options)
       end
 
-      if config.abort_on_nonzero && !result.exit_code.zero?      
-        raise VagrantPlugins::HostShell::Errors::NonZeroStatusError.new(config.inline, result.exit_code)  
+      if config.abort_on_nonzero && !result.exit_code.zero?
+        raise VagrantPlugins::HostShell::Errors::NonZeroStatusError.new(config.inline, result.exit_code)
       end
 
     end

--- a/lib/vagrant-host-shell/version.rb
+++ b/lib/vagrant-host-shell/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module HostShell
-    VERSION = '0.0.4'
+    VERSION = '0.0.5pre'
   end
 end


### PR DESCRIPTION
This will make vagrant-host-shell look much like the other provisioners and print stdout in green and stderr in red.
